### PR TITLE
Fix MM-207, Create callback for Jitsi server to validated user / host.

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -335,7 +335,7 @@ func (p *Plugin) handleCallback(w http.ResponseWriter, r *http.Request) {
 	jitsiURL = strings.TrimRight(jitsiURL, "/")
 	redirectURL := jitsiURL + "/" + room + "?jwt="
 
-	checkCallback, err2 := checkValidationCallback(user, room)
+	checkCallback, err2 := p.checkValidationCallback(user, room)
 	if err2 != nil {
 		jwtToken, err1 := p.createJwtToken(user, "invalidroom")
 		if err1 != nil {
@@ -395,10 +395,13 @@ func (p *Plugin) createJwtToken(user *model.User, room string) (string, error) {
 	claims.Context = newContext
 
 	return signClaims(p.getConfiguration().JitsiAppSecret, &claims)
-
 }
 
-func checkValidationCallback(user *model.User, room string) (bool, error) {
-
+func (p *Plugin) checkValidationCallback(user *model.User, room string) (bool, error) {
+	if p.callback.room != room {
+		return false, nil
+	} else if p.callback.UserID != user.Id {
+		return false, nil
+	}
 	return true, nil
 }

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -1,11 +1,72 @@
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
 
-func TestCallback(t *testing.T) {
-	// Case Success
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
+	"github.com/stretchr/testify/require"
+)
 
-	// Case Fail Authenticate
+func TestRedirect(t *testing.T) {
+	p := Plugin{
+		configuration: &configuration{
+			JitsiURL:          "http://test",
+			JitsiEmbedded:     false,
+			JitsiNamingScheme: "mattermost",
+			JitsiAppSecret:    "test-secret",
+			JitsiAppID:        "test-appidjitsi",
+		},
+		botID: "test-bot-id",
+	}
+	site := "http://mattermostserver"
+	servicesetting := model.ServiceSettings{SiteURL: &site}
 
-	// Case
+	t.Run("Redirect with Valid JWT", func(t *testing.T) {
+		apiMock := plugintest.API{}
+		defer apiMock.AssertExpectations(t)
+		p.SetAPI(&apiMock)
+		p.callback = CallbackValidation{
+			room:   "validroom",
+			UserID: "test-user"}
+
+		apiMock.On("GetUser", "test-user").Return(&model.User{Id: "test-user", Locale: "en"}, nil)
+		apiMock.On("GetConfig").Return(&model.Config{ServiceSettings: servicesetting})
+
+		result := p.handleRedirectURL("validroom")
+		require.True(t, strings.Contains(result, "validroom"), "Check Path should have room name")
+		require.True(t, strings.Contains(result, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"), "url has JWT header")
+	})
+
+	t.Run("Redirect to site url for login authentication", func(t *testing.T) {
+		apiMock := plugintest.API{}
+		defer apiMock.AssertExpectations(t)
+		p.SetAPI(&apiMock)
+		p.callback = CallbackValidation{
+			room:   "validroom",
+			UserID: "test-user"}
+
+		apiMock.On("GetUser", "test-user").Return(&model.User{Id: "test-user", Locale: "en"}, nil)
+		apiMock.On("GetConfig").Return(&model.Config{ServiceSettings: servicesetting})
+
+		result := p.handleRedirectURL("invalidroom")
+		require.Equal(t, site, result)
+	})
+
+	t.Run("Redirect with invalid JWT, error internal", func(t *testing.T) {
+		apiMock := plugintest.API{}
+		defer apiMock.AssertExpectations(t)
+		p.SetAPI(&apiMock)
+		p.callback = CallbackValidation{
+			room:   "validroom",
+			UserID: "test-user"}
+		apiMock.On("GetUser", "test-user").Return(&model.User{Id: "test-user", Locale: "en"}, nil)
+		apiMock.On("GetConfig").Return(&model.Config{ServiceSettings: servicesetting})
+
+		p.configuration.JitsiAppSecret = "" // error if app secret is empty string
+
+		result := p.handleRedirectURL("validroom")
+		require.True(t, strings.Contains(result, "invalidjwttoken"), "error internal, should send invalid jwt token")
+	})
 }

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -1,0 +1,11 @@
+package main
+
+import "testing"
+
+func TestCallback(t *testing.T) {
+	// Case Success
+
+	// Case Fail Authenticate
+
+	// Case
+}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -356,6 +356,13 @@ func (p *Plugin) startMeeting(user *model.User, channel *model.Channel, meetingI
 		}) + "\n\n" + meetingUntil,
 	}
 
+	callbackValidation := CallbackValidation{
+		UserID:    user.Id,
+		ChannelID: channel.Id,
+		room:      meetingID,
+	}
+	p.callback = callbackValidation
+
 	post := &model.Post{
 		UserId:    user.Id,
 		ChannelId: channel.Id,

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -35,6 +35,7 @@ type Plugin struct {
 
 	telemetryClient telemetry.Client
 	tracker         telemetry.Tracker
+	callback        CallbackValidation
 
 	// configurationLock synchronizes access to the configuration.
 	configurationLock sync.RWMutex


### PR DESCRIPTION
This PR works for this Problem [Jitsi Issue 207](https://github.com/mattermost/mattermost-plugin-jitsi/issues/207)

This PR adds a callback feature when the Jitsi Meeting URL is opened (ex: https://instance.jitsi/room).
Once the URL is open, Jitsi server will send a callback to 'mattermost-server-api' to check user validation.

Process in auth-callback expected 3 conditions.
1. validated then redirect URL to original jitsi space url with valid jwt
2. invalid, then redirect to site url to login
3. error while validating, then redirect url to original jitsi space url but with invalid jwt.

The above 3 conditions have been coded for testing.

Variables for validation are stored in the Plugin Structure.
*note, validation is only based on the room variable in the header only